### PR TITLE
Add support for hide_selector and browser_width

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ storing the images locally](config_templates/local.yaml.template) or
 
       Required. The URL of the page you are screenshotting.
 
-    - **selector** - String
+    - **target_selector** - String
 
       Optional. Defaults to `body`. The selector of the element you wish
       to screenshot.
@@ -142,6 +142,11 @@ storing the images locally](config_templates/local.yaml.template) or
 
   Optional. Default: `60`. Seconds to wait between taking screenshots
 
+- **hide_selector**
+
+  Optional. The CSS selector(s) of elements on the page which you wish to
+  hide before capturing the screnshot (works by setting `display: none;`).
+
 - **override_css_file**
 
   Optional. Path to a CSS file that overrides any existing styles on the
@@ -152,6 +157,11 @@ storing the images locally](config_templates/local.yaml.template) or
 
   Optional. Default: `2`. Seconds to wait after the page is loaded, to
   ensure that any JavaScript has finished running.
+
+- **browser_width** - Number
+
+  Optional. Default: `1440`. The width of the browser window, can be used
+  to capture a particular step in a responsive layout.
 
 - **wait_for_js_signal** - Boolean
 

--- a/config_templates/targets.yaml.template
+++ b/config_templates/targets.yaml.template
@@ -12,9 +12,9 @@ time_between_screenshots: 180
 failure_timeout: 45
 
 targets:
-    - url: http://www.washingtonpost.com/
+    - url: https://www.washingtonpost.com/
       slug: washington-post
-      selector: '#content > .wp-row > .wp-column > .container'
+      target_selector: '#right-rail > .pb-container > .pb-f-page-post-most'
       aws_subpath: screenshots/wp-hp
       page_load_delay: 2
     - url: https://news.ycombinator.com/
@@ -23,6 +23,11 @@ targets:
       page_load_delay: 4
     - url: http://www.drudgereport.com/
       slug: drudge-report
-      selector: '#drudgeTopHeadlines'
+      target_selector: '#drudgeTopHeadlines'
       aws_subpath: screenshots/dr-hp
       page_load_delay: 2
+    - url: https://www.washingtonpost.com/
+      slug: mobile-post-no-headlines
+      target_selector: '#main-content .top-table'
+      hide_selector: '.headline'
+      browser_width: 375

--- a/whippersnapper/screenshotter.py
+++ b/whippersnapper/screenshotter.py
@@ -25,22 +25,24 @@ class Screenshotter(object):
             try:
                 self.depict(
                     current_target.url,
-                    current_target.selector,
+                    current_target.target_selector,
                     current_target.local_filepath,
                     # Depict's delay argument is defined in milliseconds
-                    str(int(current_target.page_load_delay) * 1000)
+                    str(int(current_target.page_load_delay) * 1000),
+                    current_target.hide_selector,
+                    str(current_target.browser_width)
                 )
                 targets.append(current_target)
             except RuntimeError as e:
                 logging.error(e)
         return targets
 
-    def depict(self, url, selector, destination, page_load_delay):
+    def depict(self, url, target_selector, destination, page_load_delay, hide_selector, browser_width):
         """
         Runs the command-line utility `depict`.
         """
-        args = ['depict', url, destination, '-s', selector,
-                '--delay', page_load_delay]
+        args = ['depict', url, destination, '-s', target_selector,
+                '-d', page_load_delay, '-w', browser_width, '-H', hide_selector]
 
         override_css_file = self.config.get('override_css_file')
         if override_css_file:

--- a/whippersnapper/target.py
+++ b/whippersnapper/target.py
@@ -17,8 +17,8 @@ class Target(object):
             if not option in target_config:
                 raise RuntimeError('Missing required option %s' % option)
 
-        if not 'selector' in target_config:
-            target_config['selector'] = 'body'
+        if not 'target_selector' in target_config:
+            target_config['target_selector'] = 'body'
 
 
     def combine_config_options(self, global_config, target_config):
@@ -35,6 +35,8 @@ class Target(object):
             'override_css_file',
             'wait_for_js_signal',
             'failure_timeout',
+            'hide_selector',
+            'browser_width'
         ]
 
         for option in options_whitelist:

--- a/whippersnapper/whippersnapper.py
+++ b/whippersnapper/whippersnapper.py
@@ -84,8 +84,10 @@ To quit, press ^C (ctrl-C).""" % (self.log_file)
             'log_file': log_file,
             'delete_local_images': False,
             'time_between_screenshots': 60,
+            'hide_selector': ' ',
             'override_css_file': None,
             'page_load_delay': 2,
+            'browser_width': 1440,
             'wait_for_js_signal': False,
             'failure_timeout': 30,
         }


### PR DESCRIPTION
These are options supported by depict but currently can not be set through whippersnapper.

This also renames `selector` to `target_selector` to remove any ambiguity now that there are two "selector" arguments/config options.
